### PR TITLE
Rename `coupon redeem` event to prevent NaN price

### DIFF
--- a/src/components/Cart.vue
+++ b/src/components/Cart.vue
@@ -62,7 +62,7 @@ export default {
       </li>
     </ul>
 
-    <Coupon :percent="10" @select="setCoupon" />
+    <Coupon :percent="10" @redeem="setCoupon" />
 
     <div v-if="error">
       {{ error }}

--- a/src/components/Coupon.vue
+++ b/src/components/Coupon.vue
@@ -6,7 +6,7 @@ export default {
   props: ['percent'],
   setup(props, { emit }) {
     const percent = ref(props.percent);
-    const useCoupon = () => emit('select', percent.value);
+    const useCoupon = () => emit('redeem', percent.value);
 
     return { percent, useCoupon };
   }


### PR DESCRIPTION
Noticed a small bug where selecting the price in the Coupon component makes the Total price `NaN` until it is redeemed.
This is due to listening on the native `select` event, I just renamed the event to `redeem`. If you feel a different name suits better, go with that instead, just figured I should let you know.